### PR TITLE
Use h5py for output data writing and consolidation to reduce memory footprint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         'tensorflow-gpu<1.14.0',  # https://github.com/IDSIA/sacred/issues/493
         'numpy',
-        'rinokeras==1.1.1',
+        'rinokeras==1.1.2',
         'biopython',
         'sacred',
         'table_logger',


### PR DESCRIPTION
Building on https://github.com/CannyLab/rinokeras/pull/12, the data consolidation step will read the entire output dataset into memory (which will crash for relatively small datasets if we include all encoder outputs, especially for the LSTM).

hdf5 allows us to iteratively write, and avoid the memory overhead of pickle



Upon reflection, some documentation update should probably be done as well, because I think we reference pickle a few time